### PR TITLE
Don't assume that $PATH is set to include the build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,3 +74,7 @@ add_test(
 #)
 
 
+foreach (t Cs H2O ThO)
+    set_property(TEST ${t} PROPERTY ENVIRONMENT "PATH=${CMAKE_BINARY_DIR}:$ENV{PATH}")
+endforeach ()
+


### PR DESCRIPTION
Without this, `ctest` doesn't work for everyone, because the scripts may fail to find the executables.